### PR TITLE
remove maxzoom, set Maa-Amet ortho as best.

### DIFF
--- a/sources/europe/ee/EstoniaOrtho(Maaamet).geojson
+++ b/sources/europe/ee/EstoniaOrtho(Maaamet).geojson
@@ -13,7 +13,7 @@
       "text": "Maa-Ameti ortofoto",
       "required": true
     },
-    "max_zoom": 18,
+    "best": true,
     "min_zoom": 14,
     "license_url": "http://svimik.com/Maa-amet_vastus_OSM.pdf"
   },


### PR DESCRIPTION
remove maxzoom, as it is dependent on location and changes year by year.
Maa-Amet ortho is prefered local background imagery.